### PR TITLE
ZH-SRE-I246: Add nightly toolchain for test

### DIFF
--- a/.github/workflows/ci-cargo-casper.yml
+++ b/.github/workflows/ci-cargo-casper.yml
@@ -1,0 +1,48 @@
+---
+name: ci-cargo-casper
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  build_and_test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          components: rustfmt, clippy
+
+      - name: Fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: -- --check
+
+      - name: Audit
+        uses: actions-rs/cargo@v1
+        with:
+          command: audit
+
+      - name: Clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all-targets
+
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test

--- a/.github/workflows/ci-cargo-casper.yml
+++ b/.github/workflows/ci-cargo-casper.yml
@@ -19,11 +19,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get nightly toolchain from file
+        id: nightly-toolchain
+        run: echo "::set-output name=version::$(cat resources/rust-toolchain.in)"
+
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ steps.nightly-toolchain.outputs.version }}
           profile: minimal
           components: rustfmt, clippy
+          target: wasm32-unknown-unknown
 
       - name: Fmt
         uses: actions-rs/cargo@v1

--- a/.github/workflows/publish-cargo-casper.yml
+++ b/.github/workflows/publish-cargo-casper.yml
@@ -1,0 +1,24 @@
+---
+name: publish-cargo-casper
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+
+      - name: Crate Publish
+        uses: actions-rs/cargo@v1
+        with:
+          command: publish
+          args: --token ${{ secrets.crates_io_token }}


### PR DESCRIPTION
Switches:
- Toolchain from `stable` to what is present in `resources/rust-toolchain.in` for `push` & `pull_request`

Adds:
- target `wasm32-unknown-unknown`

Merges:
- `upstream/main` to pickup merged ci files